### PR TITLE
Add default styles.xml to make date columns work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,11 +83,8 @@ exports.execute = function(config, callback) {
                     return fs.writeFile(path.join(dirPath, 'data.zip'), templateXLSX, callback);
                 },
                 function(callback) {
-                    if (!config.stylesXmlFile) {
-                        return callback();
-                    }
 
-                    p = config.stylesXmlFile;
+                    p = config.stylesXmlFile || __dirname + '/styles.xml';
                     return fs.readFile(p, 'utf8', function(err, styles) {
                         if (err) {
                             return callback(err);

--- a/styles.xml
+++ b/styles.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" mc:Ignorable="x14ac">
+  <fonts count="0" x14ac:knownFonts="1">
+    <font>
+      <sz val="12" />
+      <color theme="1" />
+      <name val="Calibri" />
+      <family val="2" />
+      <scheme val="minor" />
+    </font>
+  </fonts>
+  <fills count="2">
+    <fill>
+      <patternFill patternType="none" />
+    </fill>
+    <fill>
+      <patternFill patternType="gray125" />
+    </fill>
+  </fills>
+  <borders count="1">
+    <border>
+      <left />
+      <right />
+      <top />
+      <bottom />
+      <diagonal />
+    </border>
+  </borders>
+  <cellStyleXfs count="1">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" />
+  </cellStyleXfs>
+  <cellXfs count="2">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" />
+    <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" />
+  </cellXfs>
+  <cellStyles count="1">
+    <cellStyle name="Standard" xfId="0" builtinId="0" />
+  </cellStyles>
+  <dxfs count="0" />
+  <tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleMedium4" />
+</styleSheet>


### PR DESCRIPTION
I had to add a `styles.xml` file to be able to use date columns, otherwise excel would complain about a broken file when trying to open it.

In particular the `<cellXfs>` tag seems to be necessary:

``` xml
  <cellXfs count="2">
    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" />
    <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" />
  </cellXfs>
```

because date cells are written as

``` xml
<x:c r="A2" s="1" t="n"><x:v>41791</x:v></x:c>
```

where `s="1"` references the second cell style which makes excel complain when this style is not defined in a `styles.xml`.

I testet this with Excel for Mac 14.4.6 (141106).
