### PR TITLE
Replace zipper with jszip

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "René Rössler <rene@freshx.de>"
   ],
   "license": "BSD",
-  "dependencies":{
-    "temp": "~0.7.0",
-    "zipper": "^0.3.0",
-    "async": "^0.2.10"
+  "dependencies": {
+    "async": "^0.2.10",
+    "jszip": "^2.5.0",
+    "temp": "~0.7.0"
   },
   "devDependencies": {
-     "mocha": "",
-     "should": ""
-  }  
+    "mocha": "",
+    "should": ""
+  }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -5,7 +5,7 @@ var nodeExcel = require('../index');
 
 describe('Simple Excel xlsx Export', function() {
     describe('Export', function() {
-        it('returns xlsx', function() {
+        it('returns xlsx', function(done) {
 			var conf ={};
 			conf.cols = [
 				{caption:'string', type:'string'},
@@ -20,9 +20,11 @@ describe('Simple Excel xlsx Export', function() {
         ["null", null, null, null]
 			];
 			
-            nodeExcel.execute(conf, function(err, result) {
-		var fs = require('fs');
-		fs.writeFileSync('d.xlsx', result, 'binary');			
+        nodeExcel.execute(conf, function(err, result) {
+            if (err) throw err;
+            var fs = require('fs');
+            fs.writeFileSync('d.xlsx', result, 'binary');
+            done(err);
 	    });
         });
     });


### PR DESCRIPTION
Hi!
Zipper is a dead library (last commit on May 6, 2013) and it doesn't compile on Node >= 0.12
So it's unable to use your module with it.
I replaced zipper with jszip and made corresponding fixes
